### PR TITLE
feat: add jar.mn override directives to the gen-jarmn plugin

### DIFF
--- a/libs/vite-plugin-gen-jarmn/gen_jarmanifest.ts
+++ b/libs/vite-plugin-gen-jarmn/gen_jarmanifest.ts
@@ -6,6 +6,7 @@ export async function generateJarManifest(
     prefix: string;
     namespace: string;
     register_type: "content" | "skin" | "resource";
+    overrides?: string[];
   },
 ) {
   console.log("generate jar.mn");
@@ -17,9 +18,13 @@ export async function generateJarManifest(
   }
   console.log("generate end jar.mn");
 
-  return `noraneko.jar:\n% ${options.register_type} ${options.namespace} %nora-${options.prefix}/ contentaccessible=yes\n ${Array.from(
-    new Set(arr),
-  )
+  const header = `noraneko.jar:\n% ${options.register_type} ${options.namespace} %nora-${options.prefix}/ contentaccessible=yes`;
+  const overrideLines = (options.overrides ?? [])
+    .map((o) => `\n% override ${o}`)
+    .join("");
+  const fileEntries = Array.from(new Set(arr))
     .map((v) => `nora-${options.prefix}/${v} (${v})`)
-    .join("\n ")}`;
+    .join("\n ");
+
+  return `${header}${overrideLines}\n ${fileEntries}`;
 }

--- a/libs/vite-plugin-gen-jarmn/plugin.ts
+++ b/libs/vite-plugin-gen-jarmn/plugin.ts
@@ -2,22 +2,35 @@
 
 import { generateJarManifest } from "./gen_jarmanifest.ts";
 import type { Plugin } from "rolldown";
+import fs from "node:fs";
 
 export function genJarmnPlugin(
   prefix: string,
   namespace: string,
   register_type: "content" | "skin" | "resource",
-) : Plugin {
+  pluginOptions?: { overrides?: string[] },
+) {
+  let rootPath = "";
   return {
     name: "gen_jarmn",
-    async generateBundle(options, bundle, _isWrite) {
+    configResolved(config) {
+      rootPath = config.root;
+    },
+    async generateBundle(options, bundle, isWrite) {
+      const _bundle = fs.existsSync(rootPath + "/index.html")
+        ? Object.assign(
+            { "__index.html__": { fileName: "index.html" } },
+            bundle,
+          )
+        : bundle;
       this.emitFile({
         type: "asset",
         fileName: "jar.mn",
-        source: await generateJarManifest(bundle, {
+        source: await generateJarManifest(_bundle, {
           prefix,
           namespace,
           register_type,
+          overrides: pluginOptions?.overrides,
         }),
       });
       this.emitFile({


### PR DESCRIPTION
`generateJarManifest` gains an optional `overrides` list that emits `% override` lines into the generated jar.mn, and the plugin now includes `index.html` in the manifest when one is present at the project root.

Backward-compatible: `overrides` is optional, so the existing callers (loader-modules, startup, chrome) are unaffected.